### PR TITLE
Add real-time transcription, auto-checklist, and demo UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# AssemblyAI API key for real-time streaming transcription
+# Get one at https://www.assemblyai.com/dashboard/signup
+ASSEMBLYAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ Software Engineering project at Georgia Southwestern State University.
   ```
 - **npm** (ships with Node)
 
-No other global tools, databases, or API keys are needed to run the app
-locally.
+## Environment Variables
+
+Create a `.env.local` file in the project root:
+
+```bash
+# Required for real-time transcription (AssemblyAI streaming)
+ASSEMBLYAI_API_KEY=your_api_key_here
+```
+
+Get a key at <https://www.assemblyai.com/dashboard/signup>. The app runs
+without it, but the `/demo` real-time transcription feature will return a
+500 error.
 
 ## Getting Started
 
@@ -23,6 +33,7 @@ git clone <repo-url>
 cd term-project-group-1
 nvm use 22          # ensure correct Node version
 npm install         # install dependencies
+cp .env.example .env.local  # add your ASSEMBLYAI_API_KEY
 npm run dev         # start dev server → http://localhost:3000
 ```
 
@@ -57,13 +68,29 @@ If all five pass, your branch is ready for a PR.
 
 ## API Routes
 
-| Method | Endpoint                   | Description                                   |
-| ------ | -------------------------- | --------------------------------------------- |
-| POST   | `/api/session`             | Create a call session (legacy stub)           |
-| POST   | `/api/policies`            | Upload policy text → auto-generates checklist |
-| GET    | `/api/policies`            | List all policies                             |
-| GET    | `/api/policies/[policyId]` | Get a single policy with its checklist        |
-| POST   | `/api/sessions`            | Create a session linked to a policy           |
+| Method | Endpoint                                      | Description                                   |
+| ------ | --------------------------------------------- | --------------------------------------------- |
+| POST   | `/api/session`                                | Create a call session (legacy stub)           |
+| POST   | `/api/policies`                               | Upload policy text → auto-generates checklist |
+| GET    | `/api/policies`                               | List all policies                             |
+| GET    | `/api/policies/[policyId]`                    | Get a single policy with its checklist        |
+| POST   | `/api/sessions`                               | Create a session linked to a policy           |
+| POST   | `/api/sessions/[sessionId]/transcript-events` | Ingest transcript events, auto-check items    |
+| GET    | `/api/sessions/[sessionId]/state`             | Get session, transcript, and checklist state  |
+| POST   | `/api/sessions/[sessionId]/end`               | End a session (idempotent)                    |
+| POST   | `/api/assemblyai/token`                       | Mint temporary AssemblyAI streaming token     |
+
+## Demo: Real-Time Transcription & Auto-Checklist
+
+Visit <http://localhost:3000/demo> (requires `ASSEMBLYAI_API_KEY`):
+
+1. Enter a policy name and checklist items (one per line), click
+   **Create Policy**
+2. Click **Create Session**
+3. Click **Start** and grant microphone access
+4. Speak — the transcript appears live and checklist items auto-check
+   when matching phrases are detected
+5. Click **Stop** to end the session
 
 ## Verifying the Policy Upload Path
 
@@ -112,14 +139,19 @@ npm test -- __tests__/policyUploadFlow.test.ts
 ```
 app/                  # Next.js App Router (pages, layouts, routes)
   api/                # API route handlers
+    assemblyai/       # AssemblyAI token minting
+    policies/         # Policy CRUD
+    sessions/         # Session lifecycle + transcript + state
+  demo/page.tsx       # Real-time transcription demo (client component)
   __tests__/          # Component and route tests
 lib/
   domain/types.ts     # Shared TypeScript types
-  repositories/       # In-memory data stores
+  repositories/       # In-memory data stores (globalThis for dev mode)
   services/           # Business logic layer
 __tests__/            # Service integration tests
 docs/                 # ADRs, architecture diagrams, proposal
-public/               # Static assets
+public/
+  worklets/           # AudioWorklet processors (pcm-processor.js)
 ```
 
 ## Contributing

--- a/__tests__/realTimeAutocheck.test.ts
+++ b/__tests__/realTimeAutocheck.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+import { createPolicyFromText } from "@/lib/services/policyService";
+import { createSession, endSession } from "@/lib/services/sessionService";
+import {
+  appendTranscriptEvents,
+  getTranscript,
+} from "@/lib/services/transcriptService";
+import { autoCheckChecklist } from "@/lib/services/checklistService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+describe("Week 7 — Real-time transcription & auto-checklist", () => {
+  it("checks a checklist item when transcript contains matching text", () => {
+    const policy = createPolicyFromText(
+      "Security Protocol",
+      "Verify caller identity\nConfirm account number"
+    );
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "I need to verify caller identity before proceeding",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { fullText } = getTranscript(session.id);
+    const newlyChecked = autoCheckChecklist(
+      session.id,
+      policy.checklist,
+      fullText!
+    );
+
+    expect(newlyChecked).toHaveLength(1);
+    const verifyItem = policy.checklist.find((c) =>
+      c.text.includes("Verify caller identity")
+    )!;
+    expect(newlyChecked).toContain(verifyItem.id);
+
+    const allChecked = getCheckedIds(session.id);
+    expect(allChecked).toContain(verifyItem.id);
+    expect(allChecked).not.toContain(
+      policy.checklist.find((c) => c.text.includes("Confirm account number"))!
+        .id
+    );
+  });
+
+  it("builds fullText from final entries only and stores all entries", () => {
+    const policy = createPolicyFromText("Test Policy", "Item one");
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "partial speech",
+        isFinal: false,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "final sentence one",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "another partial",
+        isFinal: false,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "final sentence two",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { entries, fullText } = getTranscript(session.id);
+
+    expect(entries).toHaveLength(4);
+    expect(fullText).toBe("final sentence one final sentence two");
+  });
+
+  it("rejects transcript events for an ended session (409)", async () => {
+    const policy = createPolicyFromText("End Test", "Some item");
+    const createResult = createSession(policy.id);
+    if (!createResult.success) throw new Error("session creation failed");
+    const session = createResult.session;
+
+    endSession(session.id);
+
+    const { POST } =
+      await import("@/app/api/sessions/[sessionId]/transcript-events/route");
+
+    const request = new Request(
+      "http://localhost/api/sessions/" + session.id + "/transcript-events",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          events: [
+            {
+              text: "hello",
+              isFinal: true,
+              occurredAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ sessionId: session.id }),
+    });
+
+    expect(response.status).toBe(409);
+  });
+
+  it("matches checklist items regardless of casing, whitespace, and punctuation", () => {
+    const policy = createPolicyFromText(
+      "Fuzzy Policy",
+      "Verify caller identity\nConfirm date of birth"
+    );
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "VERIFY   CALLER... IDENTITY!!",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "please CONFIRM   date-of-birth",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { fullText } = getTranscript(session.id);
+    const newlyChecked = autoCheckChecklist(
+      session.id,
+      policy.checklist,
+      fullText!
+    );
+
+    expect(newlyChecked).toHaveLength(2);
+    expect(newlyChecked).toContain(
+      policy.checklist.find((c) => c.text === "Verify caller identity")!.id
+    );
+    expect(newlyChecked).toContain(
+      policy.checklist.find((c) => c.text === "Confirm date of birth")!.id
+    );
+  });
+});

--- a/app/api/assemblyai/token/route.ts
+++ b/app/api/assemblyai/token/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  const apiKey = process.env.ASSEMBLYAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "ASSEMBLYAI_API_KEY not configured" },
+      { status: 500 }
+    );
+  }
+
+  const res = await fetch(
+    "https://streaming.assemblyai.com/v3/token?expires_in_seconds=60",
+    { headers: { Authorization: apiKey } }
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "unknown error");
+    return NextResponse.json(
+      { error: `AssemblyAI token request failed: ${text}` },
+      { status: 502 }
+    );
+  }
+
+  const data = await res.json();
+  return NextResponse.json({ token: data.token, expiresInSeconds: 60 });
+}

--- a/app/api/sessions/[sessionId]/end/route.ts
+++ b/app/api/sessions/[sessionId]/end/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { endSession } from "@/lib/services/sessionService";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const result = endSession(sessionId);
+
+  if (!result.success) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(result.session);
+}

--- a/app/api/sessions/[sessionId]/state/route.ts
+++ b/app/api/sessions/[sessionId]/state/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { ChecklistStateRow } from "@/lib/domain/types";
+import { getSession } from "@/lib/repositories/sessionRepo";
+import { fetchPolicy } from "@/lib/services/policyService";
+import { getTranscript } from "@/lib/services/transcriptService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const session = getSession(sessionId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const policy = fetchPolicy(session.policyId);
+  const transcript = getTranscript(sessionId);
+  const checkedIds = new Set(getCheckedIds(sessionId));
+
+  const checklistState: ChecklistStateRow[] = (policy?.checklist ?? []).map(
+    (item) => ({
+      itemId: item.id,
+      text: item.text,
+      checked: checkedIds.has(item.id),
+    })
+  );
+
+  return NextResponse.json({
+    session,
+    transcript: {
+      entries: transcript.entries,
+      fullText: transcript.fullText,
+    },
+    checklistState,
+  });
+}

--- a/app/api/sessions/[sessionId]/transcript-events/route.ts
+++ b/app/api/sessions/[sessionId]/transcript-events/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/repositories/sessionRepo";
+import { fetchPolicy } from "@/lib/services/policyService";
+import {
+  appendTranscriptEvents,
+  getTranscript,
+} from "@/lib/services/transcriptService";
+import { autoCheckChecklist } from "@/lib/services/checklistService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const session = getSession(sessionId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.status !== "active") {
+    return NextResponse.json(
+      { error: "Session is not active" },
+      { status: 409 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { events } = body as Record<string, unknown>;
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return NextResponse.json(
+      { error: "events must be a non-empty array" },
+      { status: 400 }
+    );
+  }
+
+  const { latestText } = appendTranscriptEvents(sessionId, events);
+
+  const { fullText } = getTranscript(sessionId);
+
+  const policy = fetchPolicy(session.policyId);
+  let checkedItemIds: string[] = [];
+  if (policy && fullText) {
+    autoCheckChecklist(sessionId, policy.checklist, fullText);
+  }
+  checkedItemIds = getCheckedIds(sessionId);
+
+  const { entries } = getTranscript(sessionId);
+
+  return NextResponse.json({
+    sessionId,
+    transcriptEntryCount: entries.length,
+    checkedItemIds,
+    latestText,
+  });
+}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface Policy {
+  id: string;
+  name: string;
+  checklist: { id: string; text: string }[];
+}
+
+interface Session {
+  id: string;
+  policyId: string;
+  status: string;
+}
+
+interface ChecklistStateRow {
+  itemId: string;
+  text: string;
+  checked: boolean;
+}
+
+/* ── audio buffer helper ─────────────────────── */
+
+function mergeBuffers(
+  lhs: Int16Array<ArrayBufferLike>,
+  rhs: Int16Array<ArrayBufferLike>
+): Int16Array<ArrayBuffer> {
+  const merged = new Int16Array(lhs.length + rhs.length);
+  merged.set(lhs, 0);
+  merged.set(rhs, lhs.length);
+  return merged;
+}
+
+/* ── component ───────────────────────────────── */
+
+export default function DemoPage() {
+  // policy & session state
+  const [policyName, setPolicyName] = useState("");
+  const [policyText, setPolicyText] = useState("");
+  const [policy, setPolicy] = useState<Policy | null>(null);
+  const [session, setSession] = useState<Session | null>(null);
+
+  // transcript & checklist state
+  const [transcriptText, setTranscriptText] = useState("");
+  const [checklist, setChecklist] = useState<ChecklistStateRow[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // mutable refs for audio/ws resources
+  const wsRef = useRef<WebSocket | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const turnsRef = useRef<Record<number, string>>({} as Record<number, string>);
+  const postedTurnsRef = useRef(new Set<number>());
+
+  /* ── API helpers ─────────────────────────────── */
+
+  async function createPolicy() {
+    setError(null);
+    const res = await fetch("/api/policies", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: policyName, text: policyText }),
+    });
+    if (!res.ok) {
+      setError(`Policy creation failed: ${res.status}`);
+      return;
+    }
+    const data = await res.json();
+    setPolicy(data);
+    setSession(null);
+    setChecklist([]);
+    setTranscriptText("");
+  }
+
+  async function createSession() {
+    if (!policy) return;
+    setError(null);
+    const res = await fetch("/api/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ policyId: policy.id }),
+    });
+    if (!res.ok) {
+      setError(`Session creation failed: ${res.status}`);
+      return;
+    }
+    const data = await res.json();
+    setSession(data);
+    setTranscriptText("");
+    await refreshState(data.id);
+  }
+
+  async function refreshState(sessionId: string) {
+    const res = await fetch(`/api/sessions/${sessionId}/state`);
+    if (!res.ok) return;
+    const data = await res.json();
+    setChecklist(data.checklistState);
+  }
+
+  async function postTranscriptEvent(sessionId: string, text: string) {
+    await fetch(`/api/sessions/${sessionId}/transcript-events`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [{ text, isFinal: true, occurredAt: new Date().toISOString() }],
+      }),
+    });
+    await refreshState(sessionId);
+  }
+
+  async function endSession() {
+    if (!session) return;
+    await fetch(`/api/sessions/${session.id}/end`, { method: "POST" });
+    await refreshState(session.id);
+    setSession((s) => (s ? { ...s, status: "ended" } : s));
+  }
+
+  /* ── start/stop streaming ────────────────────── */
+
+  async function startStreaming() {
+    if (!session) return;
+    setError(null);
+
+    // 1. Get temp token
+    const tokenRes = await fetch("/api/assemblyai/token", { method: "POST" });
+    if (!tokenRes.ok) {
+      setError(
+        `Token request failed: ${tokenRes.status}. Is ASSEMBLYAI_API_KEY set?`
+      );
+      return;
+    }
+    const { token } = await tokenRes.json();
+
+    // 2. Request mic permission first
+    let mediaStream: MediaStream;
+    try {
+      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      setError(`Microphone access failed: ${err}`);
+      return;
+    }
+    streamRef.current = mediaStream;
+
+    // 3. Open WebSocket with sample_rate param
+    const ws = new WebSocket(
+      `wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&formatted_finals=true&token=${token}`
+    );
+    wsRef.current = ws;
+
+    // Reset turn tracking
+    turnsRef.current = {};
+    postedTurnsRef.current = new Set();
+    let maxTurnSeen = -1;
+
+    ws.onopen = async () => {
+      setStreaming(true);
+
+      try {
+        // 4. AudioContext at 16kHz — browser resamples natively
+        const audioCtx = new AudioContext({
+          sampleRate: 16000,
+        });
+        audioCtxRef.current = audioCtx;
+        await audioCtx.audioWorklet.addModule("/worklets/pcm-processor.js");
+
+        const source = audioCtx.createMediaStreamSource(mediaStream);
+        const workletNode = new AudioWorkletNode(audioCtx, "pcm-processor");
+        source.connect(workletNode);
+        workletNode.connect(audioCtx.destination);
+
+        // 5. Buffer audio to ~100ms chunks before sending
+        let audioBufferQueue = new Int16Array(0);
+
+        workletNode.port.onmessage = (event: MessageEvent) => {
+          if (ws.readyState !== WebSocket.OPEN) return;
+
+          const currentBuffer = new Int16Array(
+            event.data.audio_data as ArrayBuffer
+          );
+          audioBufferQueue = mergeBuffers(audioBufferQueue, currentBuffer);
+
+          const bufferDuration =
+            (audioBufferQueue.length / audioCtx.sampleRate) * 1000;
+
+          if (bufferDuration >= 100) {
+            const totalSamples = Math.floor(audioCtx.sampleRate * 0.1);
+            const finalBuffer = new Uint8Array(
+              audioBufferQueue.subarray(0, totalSamples).buffer
+            );
+            audioBufferQueue = audioBufferQueue.subarray(totalSamples);
+            ws.send(finalBuffer);
+          }
+        };
+      } catch (err) {
+        setError(`Audio setup failed: ${err}`);
+        ws.close();
+        setStreaming(false);
+      }
+    };
+
+    // 6. Handle v3 Turn messages
+    ws.onmessage = (event: MessageEvent) => {
+      const msg = JSON.parse(event.data);
+      if (msg.type === "Turn") {
+        const { turn_order, transcript, end_of_turn } = msg;
+        const turns = turnsRef.current;
+        const posted = postedTurnsRef.current;
+        turns[turn_order as number] = transcript;
+
+        const fullText = Object.keys(turns)
+          .sort((a, b) => Number(a) - Number(b))
+          .map((k) => turns[Number(k)])
+          .join(" ");
+
+        setTranscriptText(fullText);
+
+        // Post previous turns that ended implicitly (new turn_order appeared)
+        if (turn_order > maxTurnSeen) {
+          for (let t = maxTurnSeen; t >= 0; t--) {
+            if (!posted.has(t) && turns[t]) {
+              posted.add(t);
+              postTranscriptEvent(session.id, turns[t]);
+            }
+          }
+          maxTurnSeen = turn_order;
+        }
+
+        // Post when AssemblyAI explicitly marks turn as ended
+        if (end_of_turn && transcript && !posted.has(turn_order)) {
+          posted.add(turn_order);
+          postTranscriptEvent(session.id, transcript);
+        }
+      }
+    };
+
+    ws.onerror = () => {
+      setError("WebSocket error — check browser console");
+      setStreaming(false);
+    };
+
+    ws.onclose = () => {
+      setStreaming(false);
+    };
+  }
+
+  async function stopStreaming() {
+    // Flush any unposted turns to backend
+    if (session) {
+      const turns = turnsRef.current;
+      const posted = postedTurnsRef.current;
+      for (const key of Object.keys(turns)) {
+        const t = Number(key);
+        if (!posted.has(t) && turns[t]) {
+          posted.add(t);
+          await postTranscriptEvent(session.id, turns[t]);
+        }
+      }
+    }
+
+    // Send terminate and close WS
+    if (wsRef.current) {
+      if (wsRef.current.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ type: "Terminate" }));
+      }
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    // Stop audio tracks
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+
+    // Close AudioContext
+    if (audioCtxRef.current) {
+      await audioCtxRef.current.close();
+      audioCtxRef.current = null;
+    }
+
+    setStreaming(false);
+    await endSession();
+  }
+
+  /* ── render ──────────────────────────────────── */
+
+  const btnBase =
+    "rounded-md px-4 py-2 text-sm font-medium text-white focus:outline-2 focus:outline-offset-2";
+
+  return (
+    <div className="mx-auto max-w-2xl p-5">
+      <h1 className="mb-6 text-2xl font-bold">Call Co-pilot Demo</h1>
+
+      {error && (
+        <div className="mb-4 rounded bg-red-100 p-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {/* ── Create Policy ─────────────────────── */}
+      <section className="mb-6">
+        <h2 className="mb-2 text-lg font-semibold">1. Create Policy</h2>
+        <input
+          type="text"
+          placeholder="Policy name"
+          value={policyName}
+          onChange={(e) => setPolicyName(e.target.value)}
+          className="mb-2 block w-full rounded border p-2 text-sm"
+        />
+        <textarea
+          placeholder={
+            "One checklist item per line, e.g.:\nVerify caller identity\nConfirm account number\nRead disclosure statement"
+          }
+          value={policyText}
+          onChange={(e) => setPolicyText(e.target.value)}
+          rows={4}
+          className="mb-2 block w-full rounded border p-2 text-sm"
+        />
+        <button
+          onClick={createPolicy}
+          disabled={!policyName.trim() || !policyText.trim()}
+          className={`${btnBase} bg-blue-600 hover:bg-blue-700 disabled:opacity-50`}
+        >
+          Create Policy
+        </button>
+        {policy && (
+          <p className="mt-2 text-sm text-gray-600">
+            Policy created: {policy.name} ({policy.checklist.length} items)
+          </p>
+        )}
+      </section>
+
+      {/* ── Create Session ────────────────────── */}
+      {policy && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-lg font-semibold">2. Create Session</h2>
+          <button
+            onClick={createSession}
+            disabled={!!session}
+            className={`${btnBase} bg-green-600 hover:bg-green-700 disabled:opacity-50`}
+          >
+            Create Session
+          </button>
+          {session && (
+            <p className="mt-2 text-sm text-gray-600">
+              Session: {session.id} ({session.status})
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* ── Checklist ─────────────────────────── */}
+      {session && checklist.length > 0 && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-lg font-semibold">Checklist</h2>
+          <ul className="space-y-1">
+            {checklist.map((item) => (
+              <li key={item.itemId} className="flex items-center gap-2 text-sm">
+                <span
+                  className={item.checked ? "text-green-600" : "text-gray-400"}
+                >
+                  {item.checked ? "[x]" : "[ ]"}
+                </span>
+                <span className={item.checked ? "line-through" : ""}>
+                  {item.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* ── Transcription controls ────────────── */}
+      {session && session.status === "active" && (
+        <section className="mb-6">
+          <h2 className="mb-2 text-lg font-semibold">3. Transcription</h2>
+          <div className="flex gap-2">
+            {!streaming ? (
+              <button
+                onClick={startStreaming}
+                className={`${btnBase} bg-green-600 hover:bg-green-700`}
+              >
+                Start
+              </button>
+            ) : (
+              <button
+                onClick={stopStreaming}
+                className={`${btnBase} bg-red-600 hover:bg-red-700`}
+              >
+                Stop
+              </button>
+            )}
+          </div>
+
+          {/* Live transcript */}
+          <div className="mt-4">
+            <h3 className="mb-1 text-sm font-medium">Live Transcript</h3>
+            <div className="min-h-[60px] rounded border bg-gray-50 p-3 text-sm text-gray-900">
+              {transcriptText || (
+                <span className="text-gray-400">
+                  {streaming
+                    ? "Listening..."
+                    : "Press Start to begin transcription"}
+                </span>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -35,3 +35,29 @@ export interface PolicyUploadRequest {
 export interface CreateSessionRequest {
   policyId: string;
 }
+
+export interface TranscriptEntry {
+  id: string;
+  sessionId: string;
+  text: string;
+  isFinal: boolean;
+  occurredAt: string;
+  confidence?: number;
+  startMs?: number;
+  endMs?: number;
+}
+
+export interface TranscriptEvent {
+  text: string;
+  isFinal: boolean;
+  occurredAt: string;
+  confidence?: number;
+  startMs?: number;
+  endMs?: number;
+}
+
+export interface ChecklistStateRow {
+  itemId: string;
+  text: string;
+  checked: boolean;
+}

--- a/lib/repositories/checklistStateRepo.ts
+++ b/lib/repositories/checklistStateRepo.ts
@@ -1,0 +1,18 @@
+const g = globalThis as unknown as {
+  _checklistState?: Map<string, Set<string>>;
+};
+const state = (g._checklistState ??= new Map<string, Set<string>>());
+
+export function markChecked(sessionId: string, itemId: string): void {
+  let checked = state.get(sessionId);
+  if (!checked) {
+    checked = new Set<string>();
+    state.set(sessionId, checked);
+  }
+  checked.add(itemId);
+}
+
+export function getCheckedIds(sessionId: string): string[] {
+  const checked = state.get(sessionId);
+  return checked ? Array.from(checked) : [];
+}

--- a/lib/repositories/policyRepo.ts
+++ b/lib/repositories/policyRepo.ts
@@ -1,6 +1,7 @@
 import { Policy, PolicySummary } from "@/lib/domain/types";
 
-const policies = new Map<string, Policy>();
+const g = globalThis as unknown as { _policies?: Map<string, Policy> };
+const policies = (g._policies ??= new Map<string, Policy>());
 
 export function savePolicy(policy: Policy): void {
   policies.set(policy.id, policy);

--- a/lib/repositories/sessionRepo.ts
+++ b/lib/repositories/sessionRepo.ts
@@ -1,6 +1,7 @@
 import { Session } from "@/lib/domain/types";
 
-const sessions = new Map<string, Session>();
+const g = globalThis as unknown as { _sessions?: Map<string, Session> };
+const sessions = (g._sessions ??= new Map<string, Session>());
 
 export function saveSession(session: Session): void {
   sessions.set(session.id, session);

--- a/lib/repositories/transcriptRepo.ts
+++ b/lib/repositories/transcriptRepo.ts
@@ -1,0 +1,19 @@
+import { TranscriptEntry } from "@/lib/domain/types";
+
+const g = globalThis as unknown as {
+  _transcripts?: Map<string, TranscriptEntry[]>;
+};
+const transcripts = (g._transcripts ??= new Map<string, TranscriptEntry[]>());
+
+export function appendEntries(
+  sessionId: string,
+  entries: TranscriptEntry[]
+): void {
+  const existing = transcripts.get(sessionId) ?? [];
+  existing.push(...entries);
+  transcripts.set(sessionId, existing);
+}
+
+export function getEntries(sessionId: string): TranscriptEntry[] {
+  return transcripts.get(sessionId) ?? [];
+}

--- a/lib/services/checklistService.ts
+++ b/lib/services/checklistService.ts
@@ -1,0 +1,35 @@
+import { ChecklistItem } from "@/lib/domain/types";
+import {
+  getCheckedIds,
+  markChecked,
+} from "@/lib/repositories/checklistStateRepo";
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function autoCheckChecklist(
+  sessionId: string,
+  checklistItems: ChecklistItem[],
+  transcriptText: string
+): string[] {
+  const alreadyChecked = new Set(getCheckedIds(sessionId));
+  const normalizedTranscript = normalize(transcriptText);
+  const newlyChecked: string[] = [];
+
+  for (const item of checklistItems) {
+    if (alreadyChecked.has(item.id)) continue;
+
+    const normalizedItem = normalize(item.text);
+    if (normalizedTranscript.includes(normalizedItem)) {
+      markChecked(sessionId, item.id);
+      newlyChecked.push(item.id);
+    }
+  }
+
+  return newlyChecked;
+}

--- a/lib/services/sessionService.ts
+++ b/lib/services/sessionService.ts
@@ -1,6 +1,6 @@
 import { Session } from "@/lib/domain/types";
 import { getPolicy } from "@/lib/repositories/policyRepo";
-import { saveSession } from "@/lib/repositories/sessionRepo";
+import { getSession, saveSession } from "@/lib/repositories/sessionRepo";
 
 type CreateSessionResult =
   | { success: true; session: Session }
@@ -21,4 +21,24 @@ export function createSession(policyId: string): CreateSessionResult {
 
   saveSession(session);
   return { success: true, session };
+}
+
+type EndSessionResult =
+  | { success: true; session: Session; alreadyEnded: boolean }
+  | { success: false; error: "not_found" };
+
+export function endSession(sessionId: string): EndSessionResult {
+  const session = getSession(sessionId);
+  if (!session) {
+    return { success: false, error: "not_found" };
+  }
+
+  if (session.status === "ended") {
+    return { success: true, session, alreadyEnded: true };
+  }
+
+  session.status = "ended";
+  session.endedAt = new Date().toISOString();
+  saveSession(session);
+  return { success: true, session, alreadyEnded: false };
 }

--- a/lib/services/transcriptService.ts
+++ b/lib/services/transcriptService.ts
@@ -1,0 +1,40 @@
+import { TranscriptEntry, TranscriptEvent } from "@/lib/domain/types";
+import {
+  appendEntries as repoAppendEntries,
+  getEntries,
+} from "@/lib/repositories/transcriptRepo";
+
+export function appendTranscriptEvents(
+  sessionId: string,
+  events: TranscriptEvent[]
+): { entryCountDelta: number; latestText: string } {
+  const entries: TranscriptEntry[] = events.map((e) => ({
+    id: crypto.randomUUID(),
+    sessionId,
+    text: e.text,
+    isFinal: e.isFinal,
+    occurredAt: e.occurredAt,
+    confidence: e.confidence,
+    startMs: e.startMs,
+    endMs: e.endMs,
+  }));
+
+  repoAppendEntries(sessionId, entries);
+
+  return {
+    entryCountDelta: entries.length,
+    latestText: entries[entries.length - 1].text,
+  };
+}
+
+export function getTranscript(sessionId: string): {
+  entries: TranscriptEntry[];
+  fullText: string | null;
+} {
+  const entries = getEntries(sessionId);
+  const finals = entries.filter((e) => e.isFinal);
+  const fullText =
+    finals.length > 0 ? finals.map((e) => e.text).join(" ") : null;
+
+  return { entries, fullText };
+}

--- a/public/worklets/pcm-processor.js
+++ b/public/worklets/pcm-processor.js
@@ -1,0 +1,17 @@
+class PcmProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || !input[0]) return true;
+
+    const float32 = input[0];
+    const int16 = new Int16Array(float32.length);
+    for (let i = 0; i < float32.length; i++) {
+      int16[i] = float32[i] * 32767;
+    }
+    this.port.postMessage({ audio_data: int16.buffer });
+
+    return true;
+  }
+}
+
+registerProcessor("pcm-processor", PcmProcessor);


### PR DESCRIPTION
## Summary

Add Week 7 Stories 2 & 3: real-time AssemblyAI WebSocket transcription with AudioWorklet mic capture, transcript-driven auto-checklist matching, session lifecycle routes, and an interactive `/demo` page that ties it all together.

---

## Why

The MVP needs live transcription and automatic compliance-checklist verification so call-center agents get real-time feedback during a call. This PR wires up the full pipeline: mic → AudioWorklet (16 kHz PCM) → AssemblyAI streaming WS → backend transcript ingestion → fuzzy checklist matching → live UI updates.

---

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure/CI

---

## Checklist

- [x] Branch follows naming convention
- [x] PR opened early
- [x] CI checks pass
- [x] Lint/format run locally
- [x] At least one reviewer assigned
- [x] Tests added or test plan described
- [x] Documentation updated (if applicable)

---

## Notes for Reviewer

**New files (17 changed, +946 lines):**

- `app/demo/page.tsx` — full demo UI (mic capture, WS streaming, live transcript, auto-checklist)
- `app/api/assemblyai/token/route.ts` — mints 60s temp tokens server-side (keeps API key off the client)
- `app/api/sessions/[sessionId]/transcript-events/route.ts` — ingests transcript events, runs auto-check
- `app/api/sessions/[sessionId]/state/route.ts` — returns session + transcript + checklist state
- `app/api/sessions/[sessionId]/end/route.ts` — idempotent session end
- `lib/services/transcriptService.ts` — append events, build fullText from finals
- `lib/services/checklistService.ts` — fuzzy normalize-and-includes matching
- `lib/repositories/transcriptRepo.ts` + `checklistStateRepo.ts` — in-memory stores
- `public/worklets/pcm-processor.js` — Float32→Int16 conversion in AudioWorklet
- `__tests__/realTimeAutocheck.test.ts` — 4 integration tests for the auto-check pipeline

**globalThis on repos:** All 4 repository files use the `globalThis` singleton pattern to survive Next.js dev-mode module re-evaluation (same approach Prisma recommends). Without this, each route gets its own Map instance and cross-route lookups return 404.

**To try locally:** `cp .env.example .env.local`, add your AssemblyAI key, `npm run dev`, open `/demo`.