### PR TITLE
Add transcript ingestion, auto-checklist matching, and session lifecycle

### DIFF
--- a/__tests__/realTimeAutocheck.test.ts
+++ b/__tests__/realTimeAutocheck.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ */
+import { createPolicyFromText } from "@/lib/services/policyService";
+import { createSession, endSession } from "@/lib/services/sessionService";
+import {
+  appendTranscriptEvents,
+  getTranscript,
+} from "@/lib/services/transcriptService";
+import { autoCheckChecklist } from "@/lib/services/checklistService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+describe("Week 7 — Real-time transcription & auto-checklist", () => {
+  it("checks a checklist item when transcript contains matching text", () => {
+    const policy = createPolicyFromText(
+      "Security Protocol",
+      "Verify caller identity\nConfirm account number"
+    );
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "I need to verify caller identity before proceeding",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { fullText } = getTranscript(session.id);
+    const newlyChecked = autoCheckChecklist(
+      session.id,
+      policy.checklist,
+      fullText!
+    );
+
+    expect(newlyChecked).toHaveLength(1);
+    const verifyItem = policy.checklist.find((c) =>
+      c.text.includes("Verify caller identity")
+    )!;
+    expect(newlyChecked).toContain(verifyItem.id);
+
+    const allChecked = getCheckedIds(session.id);
+    expect(allChecked).toContain(verifyItem.id);
+    expect(allChecked).not.toContain(
+      policy.checklist.find((c) => c.text.includes("Confirm account number"))!
+        .id
+    );
+  });
+
+  it("builds fullText from final entries only and stores all entries", () => {
+    const policy = createPolicyFromText("Test Policy", "Item one");
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "partial speech",
+        isFinal: false,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "final sentence one",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "another partial",
+        isFinal: false,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "final sentence two",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { entries, fullText } = getTranscript(session.id);
+
+    expect(entries).toHaveLength(4);
+    expect(fullText).toBe("final sentence one final sentence two");
+  });
+
+  it("rejects transcript events for an ended session (409)", async () => {
+    const policy = createPolicyFromText("End Test", "Some item");
+    const createResult = createSession(policy.id);
+    if (!createResult.success) throw new Error("session creation failed");
+    const session = createResult.session;
+
+    endSession(session.id);
+
+    const { POST } =
+      await import("@/app/api/sessions/[sessionId]/transcript-events/route");
+
+    const request = new Request(
+      "http://localhost/api/sessions/" + session.id + "/transcript-events",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          events: [
+            {
+              text: "hello",
+              isFinal: true,
+              occurredAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ sessionId: session.id }),
+    });
+
+    expect(response.status).toBe(409);
+  });
+
+  it("matches checklist items regardless of casing, whitespace, and punctuation", () => {
+    const policy = createPolicyFromText(
+      "Fuzzy Policy",
+      "Verify caller identity\nConfirm date of birth"
+    );
+    const result = createSession(policy.id);
+    if (!result.success) throw new Error("session creation failed");
+    const session = result.session;
+
+    appendTranscriptEvents(session.id, [
+      {
+        text: "VERIFY   CALLER... IDENTITY!!",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+      {
+        text: "please CONFIRM   date-of-birth",
+        isFinal: true,
+        occurredAt: new Date().toISOString(),
+      },
+    ]);
+
+    const { fullText } = getTranscript(session.id);
+    const newlyChecked = autoCheckChecklist(
+      session.id,
+      policy.checklist,
+      fullText!
+    );
+
+    expect(newlyChecked).toHaveLength(2);
+    expect(newlyChecked).toContain(
+      policy.checklist.find((c) => c.text === "Verify caller identity")!.id
+    );
+    expect(newlyChecked).toContain(
+      policy.checklist.find((c) => c.text === "Confirm date of birth")!.id
+    );
+  });
+});

--- a/app/api/sessions/[sessionId]/end/route.ts
+++ b/app/api/sessions/[sessionId]/end/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { endSession } from "@/lib/services/sessionService";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const result = endSession(sessionId);
+
+  if (!result.success) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(result.session);
+}

--- a/app/api/sessions/[sessionId]/state/route.ts
+++ b/app/api/sessions/[sessionId]/state/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { ChecklistStateRow } from "@/lib/domain/types";
+import { getSession } from "@/lib/repositories/sessionRepo";
+import { fetchPolicy } from "@/lib/services/policyService";
+import { getTranscript } from "@/lib/services/transcriptService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const session = getSession(sessionId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const policy = fetchPolicy(session.policyId);
+  const transcript = getTranscript(sessionId);
+  const checkedIds = new Set(getCheckedIds(sessionId));
+
+  const checklistState: ChecklistStateRow[] = (policy?.checklist ?? []).map(
+    (item) => ({
+      itemId: item.id,
+      text: item.text,
+      checked: checkedIds.has(item.id),
+    })
+  );
+
+  return NextResponse.json({
+    session,
+    transcript: {
+      entries: transcript.entries,
+      fullText: transcript.fullText,
+    },
+    checklistState,
+  });
+}

--- a/app/api/sessions/[sessionId]/transcript-events/route.ts
+++ b/app/api/sessions/[sessionId]/transcript-events/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/repositories/sessionRepo";
+import { fetchPolicy } from "@/lib/services/policyService";
+import {
+  appendTranscriptEvents,
+  getTranscript,
+} from "@/lib/services/transcriptService";
+import { autoCheckChecklist } from "@/lib/services/checklistService";
+import { getCheckedIds } from "@/lib/repositories/checklistStateRepo";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const session = getSession(sessionId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.status !== "active") {
+    return NextResponse.json(
+      { error: "Session is not active" },
+      { status: 409 }
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { events } = body as Record<string, unknown>;
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return NextResponse.json(
+      { error: "events must be a non-empty array" },
+      { status: 400 }
+    );
+  }
+
+  const { latestText } = appendTranscriptEvents(sessionId, events);
+
+  const { fullText } = getTranscript(sessionId);
+
+  const policy = fetchPolicy(session.policyId);
+  let checkedItemIds: string[] = [];
+  if (policy && fullText) {
+    autoCheckChecklist(sessionId, policy.checklist, fullText);
+  }
+  checkedItemIds = getCheckedIds(sessionId);
+
+  const { entries } = getTranscript(sessionId);
+
+  return NextResponse.json({
+    sessionId,
+    transcriptEntryCount: entries.length,
+    checkedItemIds,
+    latestText,
+  });
+}

--- a/lib/domain/types.ts
+++ b/lib/domain/types.ts
@@ -35,3 +35,29 @@ export interface PolicyUploadRequest {
 export interface CreateSessionRequest {
   policyId: string;
 }
+
+export interface TranscriptEntry {
+  id: string;
+  sessionId: string;
+  text: string;
+  isFinal: boolean;
+  occurredAt: string;
+  confidence?: number;
+  startMs?: number;
+  endMs?: number;
+}
+
+export interface TranscriptEvent {
+  text: string;
+  isFinal: boolean;
+  occurredAt: string;
+  confidence?: number;
+  startMs?: number;
+  endMs?: number;
+}
+
+export interface ChecklistStateRow {
+  itemId: string;
+  text: string;
+  checked: boolean;
+}

--- a/lib/repositories/checklistStateRepo.ts
+++ b/lib/repositories/checklistStateRepo.ts
@@ -1,0 +1,18 @@
+const g = globalThis as unknown as {
+  _checklistState?: Map<string, Set<string>>;
+};
+const state = (g._checklistState ??= new Map<string, Set<string>>());
+
+export function markChecked(sessionId: string, itemId: string): void {
+  let checked = state.get(sessionId);
+  if (!checked) {
+    checked = new Set<string>();
+    state.set(sessionId, checked);
+  }
+  checked.add(itemId);
+}
+
+export function getCheckedIds(sessionId: string): string[] {
+  const checked = state.get(sessionId);
+  return checked ? Array.from(checked) : [];
+}

--- a/lib/repositories/policyRepo.ts
+++ b/lib/repositories/policyRepo.ts
@@ -1,6 +1,7 @@
 import { Policy, PolicySummary } from "@/lib/domain/types";
 
-const policies = new Map<string, Policy>();
+const g = globalThis as unknown as { _policies?: Map<string, Policy> };
+const policies = (g._policies ??= new Map<string, Policy>());
 
 export function savePolicy(policy: Policy): void {
   policies.set(policy.id, policy);

--- a/lib/repositories/sessionRepo.ts
+++ b/lib/repositories/sessionRepo.ts
@@ -1,6 +1,7 @@
 import { Session } from "@/lib/domain/types";
 
-const sessions = new Map<string, Session>();
+const g = globalThis as unknown as { _sessions?: Map<string, Session> };
+const sessions = (g._sessions ??= new Map<string, Session>());
 
 export function saveSession(session: Session): void {
   sessions.set(session.id, session);

--- a/lib/repositories/transcriptRepo.ts
+++ b/lib/repositories/transcriptRepo.ts
@@ -1,0 +1,19 @@
+import { TranscriptEntry } from "@/lib/domain/types";
+
+const g = globalThis as unknown as {
+  _transcripts?: Map<string, TranscriptEntry[]>;
+};
+const transcripts = (g._transcripts ??= new Map<string, TranscriptEntry[]>());
+
+export function appendEntries(
+  sessionId: string,
+  entries: TranscriptEntry[]
+): void {
+  const existing = transcripts.get(sessionId) ?? [];
+  existing.push(...entries);
+  transcripts.set(sessionId, existing);
+}
+
+export function getEntries(sessionId: string): TranscriptEntry[] {
+  return transcripts.get(sessionId) ?? [];
+}

--- a/lib/services/checklistService.ts
+++ b/lib/services/checklistService.ts
@@ -1,0 +1,35 @@
+import { ChecklistItem } from "@/lib/domain/types";
+import {
+  getCheckedIds,
+  markChecked,
+} from "@/lib/repositories/checklistStateRepo";
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function autoCheckChecklist(
+  sessionId: string,
+  checklistItems: ChecklistItem[],
+  transcriptText: string
+): string[] {
+  const alreadyChecked = new Set(getCheckedIds(sessionId));
+  const normalizedTranscript = normalize(transcriptText);
+  const newlyChecked: string[] = [];
+
+  for (const item of checklistItems) {
+    if (alreadyChecked.has(item.id)) continue;
+
+    const normalizedItem = normalize(item.text);
+    if (normalizedTranscript.includes(normalizedItem)) {
+      markChecked(sessionId, item.id);
+      newlyChecked.push(item.id);
+    }
+  }
+
+  return newlyChecked;
+}

--- a/lib/services/sessionService.ts
+++ b/lib/services/sessionService.ts
@@ -1,6 +1,6 @@
 import { Session } from "@/lib/domain/types";
 import { getPolicy } from "@/lib/repositories/policyRepo";
-import { saveSession } from "@/lib/repositories/sessionRepo";
+import { getSession, saveSession } from "@/lib/repositories/sessionRepo";
 
 type CreateSessionResult =
   | { success: true; session: Session }
@@ -21,4 +21,24 @@ export function createSession(policyId: string): CreateSessionResult {
 
   saveSession(session);
   return { success: true, session };
+}
+
+type EndSessionResult =
+  | { success: true; session: Session; alreadyEnded: boolean }
+  | { success: false; error: "not_found" };
+
+export function endSession(sessionId: string): EndSessionResult {
+  const session = getSession(sessionId);
+  if (!session) {
+    return { success: false, error: "not_found" };
+  }
+
+  if (session.status === "ended") {
+    return { success: true, session, alreadyEnded: true };
+  }
+
+  session.status = "ended";
+  session.endedAt = new Date().toISOString();
+  saveSession(session);
+  return { success: true, session, alreadyEnded: false };
 }

--- a/lib/services/transcriptService.ts
+++ b/lib/services/transcriptService.ts
@@ -1,0 +1,40 @@
+import { TranscriptEntry, TranscriptEvent } from "@/lib/domain/types";
+import {
+  appendEntries as repoAppendEntries,
+  getEntries,
+} from "@/lib/repositories/transcriptRepo";
+
+export function appendTranscriptEvents(
+  sessionId: string,
+  events: TranscriptEvent[]
+): { entryCountDelta: number; latestText: string } {
+  const entries: TranscriptEntry[] = events.map((e) => ({
+    id: crypto.randomUUID(),
+    sessionId,
+    text: e.text,
+    isFinal: e.isFinal,
+    occurredAt: e.occurredAt,
+    confidence: e.confidence,
+    startMs: e.startMs,
+    endMs: e.endMs,
+  }));
+
+  repoAppendEntries(sessionId, entries);
+
+  return {
+    entryCountDelta: entries.length,
+    latestText: entries[entries.length - 1].text,
+  };
+}
+
+export function getTranscript(sessionId: string): {
+  entries: TranscriptEntry[];
+  fullText: string | null;
+} {
+  const entries = getEntries(sessionId);
+  const finals = entries.filter((e) => e.isFinal);
+  const fullText =
+    finals.length > 0 ? finals.map((e) => e.text).join(" ") : null;
+
+  return { entries, fullText };
+}


### PR DESCRIPTION
## Summary

Story 3 backend: transcript ingestion, fuzzy auto-checklist matching, and session end/state routes. Adds the full backend pipeline so transcript events auto-check compliance checklist items.

---

## Why

The call co-pilot needs a backend that accepts live transcript text, matches it against policy checklist items, and tracks which items have been satisfied. This PR implements that pipeline with three new API routes, two new services, and two new in-memory repositories.

---

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure/CI

---

## Checklist

- [x] Branch follows naming convention
- [x] PR opened early
- [x] CI checks pass
- [x] Lint/format run locally
- [x] At least one reviewer assigned
- [x] Tests added or test plan described
- [x] Documentation updated (if applicable)

---

## Notes for Reviewer

**New files (12 changed, +442 lines):**

- `lib/domain/types.ts` — added `TranscriptEntry`, `TranscriptEvent`, `ChecklistStateRow` interfaces
- `lib/repositories/transcriptRepo.ts` + `checklistStateRepo.ts` — in-memory stores (globalThis singleton)
- `lib/repositories/policyRepo.ts` + `sessionRepo.ts` — migrated to globalThis to fix dev-mode module isolation
- `lib/services/transcriptService.ts` — append events, build fullText from finals
- `lib/services/checklistService.ts` — normalize-and-includes fuzzy matching
- `lib/services/sessionService.ts` — added `endSession()` with discriminated union return
- `app/api/sessions/[sessionId]/transcript-events/route.ts` — POST: ingest events, run auto-check
- `app/api/sessions/[sessionId]/state/route.ts` — GET: session + transcript + checklist state
- `app/api/sessions/[sessionId]/end/route.ts` — POST: idempotent session end
- `__tests__/realTimeAutocheck.test.ts` — 4 integration tests covering happy path, finals-only, 409 on ended session, fuzzy matching

**globalThis pattern:** All repos use `globalThis` to survive Next.js dev-mode module re-evaluation (same pattern Prisma recommends). Without this, each route handler gets its own Map instance and cross-route lookups return 404.