### PR TITLE
Add week 9 PR index document

### DIFF
--- a/docs/beta/week9-pr-index.md
+++ b/docs/beta/week9-pr-index.md
@@ -1,7 +1,7 @@
 # Week 9 — Pull Request Index
 
-| PR | Backlog Item | Impact |
-|----|-------------|--------|
-| [#31 — Add real-time acoustic frequency analysis (FFT)](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/31) | Acoustic Signal Processing | Extracts fundamental frequency from live PCM audio via FFT, enabling real-time voice stress visualization. |
-| [#32 — Add transcript windowing to bound memory usage](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/32) | Transcription Optimization | Prunes old transcript entries once text exceeds a character limit, keeping memory stable during long calls. |
-| [#33 — Add structured logging and input validation to API routes](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/33) | Structured Logging | Adds JSON-structured logs with timestamps, event types, and session IDs to every API route for error tracing and action auditing. |
+| PR                                                                                                                                                       | Backlog Item               | Impact                                                                                                                            |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [#31 — Add real-time acoustic frequency analysis (FFT)](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/31)           | Acoustic Signal Processing | Extracts fundamental frequency from live PCM audio via FFT, enabling real-time voice stress visualization.                        |
+| [#32 — Add transcript windowing to bound memory usage](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/32)            | Transcription Optimization | Prunes old transcript entries once text exceeds a character limit, keeping memory stable during long calls.                       |
+| [#33 — Add structured logging and input validation to API routes](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-1/pull/33) | Structured Logging         | Adds JSON-structured logs with timestamps, event types, and session IDs to every API route for error tracing and action auditing. |


### PR DESCRIPTION
## Summary

- Add `docs/beta/week9-pr-index.md` listing the week 9 pull requests and their purposes for easy reference.

---

## Why

Provides a single reference document that maps each week 9 PR to its purpose, making it easier for reviewers and the team to track sprint progress.

---

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure/CI

---

## Checklist

- [x] Branch follows naming convention
- [x] PR opened early
- [x] CI checks pass
- [x] Lint/format run locally
- [x] At least one reviewer assigned
- [ ] Tests added or test plan described
- [x] Documentation updated (if applicable)

---

## Notes for Reviewer

Documentation-only change — no code impact.