### PR TITLE
Refactor: Extract request validation helper (Week 13 Deliverable B)

### DIFF
--- a/app/__tests__/call-page.test.tsx
+++ b/app/__tests__/call-page.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import CallPage from "../call/page";
 
 beforeEach(() => {
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve([]),
+    json: () => Promise.resolve({ policies: [] }),
   });
 });
 
@@ -13,8 +13,10 @@ afterEach(() => {
 });
 
 describe("CallPage", () => {
-  it("renders the heading and start button", () => {
-    render(<CallPage />);
+  it("renders the heading and start button", async () => {
+    await act(async () => {
+      render(<CallPage />);
+    });
     expect(
       screen.getByRole("heading", { name: "Start Call Session" })
     ).toBeInTheDocument();
@@ -23,21 +25,27 @@ describe("CallPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders policy selector", () => {
-    render(<CallPage />);
+  it("renders policy selector", async () => {
+    await act(async () => {
+      render(<CallPage />);
+    });
     expect(screen.getByText("Select Policy")).toBeInTheDocument();
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it("disables start button when no policy selected", () => {
-    render(<CallPage />);
+  it("disables start button when no policy selected", async () => {
+    await act(async () => {
+      render(<CallPage />);
+    });
     expect(
       screen.getByRole("button", { name: "Start Session" })
     ).toBeDisabled();
   });
 
-  it("fetches policies on mount", () => {
-    render(<CallPage />);
+  it("fetches policies on mount", async () => {
+    await act(async () => {
+      render(<CallPage />);
+    });
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/policies",
       expect.objectContaining({

--- a/app/__tests__/parse-request-body.test.ts
+++ b/app/__tests__/parse-request-body.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for parseRequestBody utility and frequencyEventSchema.
+ * Protects the refactor that extracted duplicated JSON-parse + Zod-validate
+ * boilerplate from 4 API route handlers into a shared helper.
+ */
+import { z } from "zod/v4";
+import { parseRequestBody } from "@/lib/validation/parseRequestBody";
+import { frequencyEventSchema } from "@/lib/validation/schemas";
+
+/* ── helpers ─────────────────────────────────── */
+
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function invalidJsonRequest(): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "not-json!!!{",
+  });
+}
+
+const simpleSchema = z.object({
+  name: z.string().min(1, "name is required"),
+  count: z.number(),
+});
+
+/* ── parseRequestBody ────────────────────────── */
+
+describe("parseRequestBody", () => {
+  it("returns parsed data for a valid request", async () => {
+    const result = await parseRequestBody(
+      jsonRequest({ name: "test", count: 5 }),
+      simpleSchema,
+      "TEST /route"
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ name: "test", count: 5 });
+    }
+  });
+
+  it("returns 400 response for malformed JSON", async () => {
+    const result = await parseRequestBody(
+      invalidJsonRequest(),
+      simpleSchema,
+      "TEST /route"
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(body.error).toBe("Invalid JSON body");
+    }
+  });
+
+  it("returns 400 response with field-level message for schema violations", async () => {
+    const result = await parseRequestBody(
+      jsonRequest({ name: "", count: "not-a-number" }),
+      simpleSchema,
+      "TEST /route"
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+      const body = await result.response.json();
+      expect(body.error).toContain("name");
+    }
+  });
+
+  it("returns 400 for completely wrong shape", async () => {
+    const result = await parseRequestBody(
+      jsonRequest("just a string"),
+      simpleSchema,
+      "TEST /route"
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.response.status).toBe(400);
+    }
+  });
+});
+
+/* ── frequencyEventSchema ────────────────────── */
+
+describe("frequencyEventSchema", () => {
+  const validEvent = {
+    dominantFrequencyHz: 440,
+    frequencyBins: [-50, -48, -55],
+    sampleRateHz: 16000,
+    fftSize: 2048,
+    binResolutionHz: 7.8125,
+  };
+
+  it("accepts a valid frequency event", () => {
+    const result = frequencyEventSchema.safeParse(validEvent);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts zero for dominantFrequencyHz", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      dominantFrequencyHz: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty frequencyBins array", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      frequencyBins: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative dominantFrequencyHz", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      dominantFrequencyHz: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects NaN dominantFrequencyHz", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      dominantFrequencyHz: NaN,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects Infinity sampleRateHz", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      sampleRateHz: Infinity,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects zero sampleRateHz (must be positive)", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      sampleRateHz: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer fftSize", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      fftSize: 2048.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects zero fftSize", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      fftSize: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-number in frequencyBins", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      frequencyBins: [-50, "oops", -55],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing fields", () => {
+    const result = frequencyEventSchema.safeParse({
+      dominantFrequencyHz: 440,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects frequencyBins exceeding max length (4096)", () => {
+    const result = frequencyEventSchema.safeParse({
+      ...validEvent,
+      frequencyBins: new Array(4097).fill(0),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/app/api/policies/route.ts
+++ b/app/api/policies/route.ts
@@ -5,42 +5,17 @@ import {
 } from "@/lib/services/policyService";
 import { authenticateRequest, authErrorResponse } from "@/lib/auth";
 import { logger } from "@/lib/logger";
-import {
-  createPolicyBodySchema,
-  formatZodError,
-} from "@/lib/validation/schemas";
+import { createPolicyBodySchema } from "@/lib/validation/schemas";
+import { parseRequestBody } from "@/lib/validation/parseRequestBody";
+
+const ROUTE = "POST /api/policies";
 
 export async function POST(request: Request) {
   const authResult = await authenticateRequest(request);
   if (!authResult.success) return authErrorResponse(authResult.error);
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    logger.error("api.error", {
-      data: {
-        route: "POST /api/policies",
-        status: 400,
-        reason: "Invalid JSON body",
-      },
-    });
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
 
-  const parsed = createPolicyBodySchema.safeParse(body);
-  if (!parsed.success) {
-    const message = formatZodError(parsed.error.issues);
-    const field = String(parsed.error.issues[0]?.path?.[0] ?? "");
-    logger.error("api.error", {
-      data: {
-        route: "POST /api/policies",
-        status: 400,
-        ...(field && { field }),
-        reason: message,
-      },
-    });
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(request, createPolicyBodySchema, ROUTE);
+  if (!parsed.success) return parsed.response;
 
   const policy = await createPolicyFromText(parsed.data.name, parsed.data.text);
 

--- a/app/api/sessions/[sessionId]/frequency/route.ts
+++ b/app/api/sessions/[sessionId]/frequency/route.ts
@@ -7,77 +7,10 @@ import {
   authErrorResponse,
   assertOwnership,
 } from "@/lib/auth";
+import { frequencyEventSchema } from "@/lib/validation/schemas";
+import { parseRequestBody } from "@/lib/validation/parseRequestBody";
 
-const MAX_FREQUENCY_BINS = 4096;
-
-function isFinitePositive(v: unknown): v is number {
-  return typeof v === "number" && Number.isFinite(v) && v > 0;
-}
-
-function validateFrequencyEvent(
-  body: Record<string, unknown>
-): { valid: true } | { valid: false; message: string } {
-  if (
-    typeof body.dominantFrequencyHz !== "number" ||
-    !Number.isFinite(body.dominantFrequencyHz) ||
-    body.dominantFrequencyHz < 0
-  ) {
-    return {
-      valid: false,
-      message: "'dominantFrequencyHz' must be a finite non-negative number",
-    };
-  }
-
-  if (!Array.isArray(body.frequencyBins)) {
-    return { valid: false, message: "'frequencyBins' must be an array" };
-  }
-
-  if (body.frequencyBins.length > MAX_FREQUENCY_BINS) {
-    return {
-      valid: false,
-      message: `'frequencyBins' exceeds maximum length of ${MAX_FREQUENCY_BINS}`,
-    };
-  }
-
-  for (let i = 0; i < body.frequencyBins.length; i++) {
-    if (
-      typeof body.frequencyBins[i] !== "number" ||
-      !Number.isFinite(body.frequencyBins[i])
-    ) {
-      return {
-        valid: false,
-        message: `'frequencyBins[${i}]' must be a finite number`,
-      };
-    }
-  }
-
-  if (!isFinitePositive(body.sampleRateHz)) {
-    return {
-      valid: false,
-      message: "'sampleRateHz' must be a positive finite number",
-    };
-  }
-
-  if (
-    typeof body.fftSize !== "number" ||
-    !Number.isInteger(body.fftSize) ||
-    body.fftSize <= 0
-  ) {
-    return {
-      valid: false,
-      message: "'fftSize' must be a positive integer",
-    };
-  }
-
-  if (!isFinitePositive(body.binResolutionHz)) {
-    return {
-      valid: false,
-      message: "'binResolutionHz' must be a positive finite number",
-    };
-  }
-
-  return { valid: true };
-}
+const ROUTE = "POST /api/sessions/[id]/frequency";
 
 export async function POST(
   request: Request,
@@ -93,7 +26,7 @@ export async function POST(
   if (!session) {
     logger.error("api.error", {
       sessionId,
-      data: { route: "POST /api/sessions/[id]/frequency", status: 404 },
+      data: { route: ROUTE, status: 404 },
     });
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
@@ -104,11 +37,7 @@ export async function POST(
   if (session.status !== "active") {
     logger.error("api.error", {
       sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/frequency",
-        status: 409,
-        currentStatus: session.status,
-      },
+      data: { route: ROUTE, status: 409, currentStatus: session.status },
     });
     return NextResponse.json(
       { error: "Session is not active" },
@@ -116,45 +45,19 @@ export async function POST(
     );
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    logger.error("api.error", {
-      sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/frequency",
-        status: 400,
-        reason: "Invalid JSON body",
-      },
-    });
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const event = body as Record<string, unknown>;
-
-  const validation = validateFrequencyEvent(event);
-  if (!validation.valid) {
-    logger.error("api.error", {
-      sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/frequency",
-        status: 400,
-        reason: validation.message,
-      },
-    });
-    return NextResponse.json({ error: validation.message }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(
+    request,
+    frequencyEventSchema,
+    ROUTE,
+    sessionId
+  );
+  if (!parsed.success) return parsed.response;
 
   const snapshot = {
     id: crypto.randomUUID(),
     sessionId,
     occurredAt: new Date().toISOString(),
-    dominantFrequencyHz: event.dominantFrequencyHz as number,
-    frequencyBins: event.frequencyBins as number[],
-    sampleRateHz: event.sampleRateHz as number,
-    fftSize: event.fftSize as number,
-    binResolutionHz: event.binResolutionHz as number,
+    ...parsed.data,
   };
 
   await appendSnapshot(sessionId, snapshot);

--- a/app/api/sessions/[sessionId]/transcript-events/route.ts
+++ b/app/api/sessions/[sessionId]/transcript-events/route.ts
@@ -14,10 +14,10 @@ import {
   assertOwnership,
 } from "@/lib/auth";
 import { logger } from "@/lib/logger";
-import {
-  transcriptEventsBodySchema,
-  formatZodError,
-} from "@/lib/validation/schemas";
+import { transcriptEventsBodySchema } from "@/lib/validation/schemas";
+import { parseRequestBody } from "@/lib/validation/parseRequestBody";
+
+const ROUTE = "POST /api/sessions/[id]/transcript-events";
 
 export async function POST(
   request: Request,
@@ -33,7 +33,7 @@ export async function POST(
   if (!session) {
     logger.error("api.error", {
       sessionId,
-      data: { route: "POST /api/sessions/[id]/transcript-events", status: 404 },
+      data: { route: ROUTE, status: 404 },
     });
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
@@ -44,11 +44,7 @@ export async function POST(
   if (session.status !== "active") {
     logger.error("api.error", {
       sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/transcript-events",
-        status: 409,
-        currentStatus: session.status,
-      },
+      data: { route: ROUTE, status: 409, currentStatus: session.status },
     });
     return NextResponse.json(
       { error: "Session is not active" },
@@ -56,34 +52,13 @@ export async function POST(
     );
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    logger.error("api.error", {
-      sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/transcript-events",
-        status: 400,
-        reason: "Invalid JSON body",
-      },
-    });
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const parsed = transcriptEventsBodySchema.safeParse(body);
-  if (!parsed.success) {
-    const message = formatZodError(parsed.error.issues);
-    logger.error("api.error", {
-      sessionId,
-      data: {
-        route: "POST /api/sessions/[id]/transcript-events",
-        status: 400,
-        reason: message,
-      },
-    });
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(
+    request,
+    transcriptEventsBodySchema,
+    ROUTE,
+    sessionId
+  );
+  if (!parsed.success) return parsed.response;
 
   try {
     const typedEvents = parsed.data.events as TranscriptEvent[];

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -5,10 +5,10 @@ import {
 } from "@/lib/services/sessionService";
 import { authenticateRequest, authErrorResponse } from "@/lib/auth";
 import { logger } from "@/lib/logger";
-import {
-  createSessionBodySchema,
-  formatZodError,
-} from "@/lib/validation/schemas";
+import { createSessionBodySchema } from "@/lib/validation/schemas";
+import { parseRequestBody } from "@/lib/validation/parseRequestBody";
+
+const POST_ROUTE = "POST /api/sessions";
 
 export async function GET(request: Request) {
   const authResult = await authenticateRequest(request);
@@ -45,28 +45,12 @@ export async function POST(request: Request) {
   if (!authResult.success) return authErrorResponse(authResult.error);
   const { auth } = authResult;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    logger.error("api.error", {
-      data: {
-        route: "POST /api/sessions",
-        status: 400,
-        reason: "Invalid JSON body",
-      },
-    });
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const parsed = createSessionBodySchema.safeParse(body);
-  if (!parsed.success) {
-    const message = formatZodError(parsed.error.issues);
-    logger.error("api.error", {
-      data: { route: "POST /api/sessions", status: 400, field: "policyId" },
-    });
-    return NextResponse.json({ error: message }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(
+    request,
+    createSessionBodySchema,
+    POST_ROUTE
+  );
+  if (!parsed.success) return parsed.response;
 
   try {
     const result = await createSession(parsed.data.policyId, auth.userId);

--- a/docs/final/week13-refactoring.md
+++ b/docs/final/week13-refactoring.md
@@ -132,5 +132,5 @@ All 17 pre-existing tests covering the affected routes continue to pass, confirm
 
 ### Related PR
 
-- PR: TBD (this branch: `refactor/extract-request-validation-helper`)
+- PR: #57 (`refactor/extract-request-validation-helper`)
 - Teammate's PR: #56 (sprint goal / hand-off)

--- a/docs/final/week13-refactoring.md
+++ b/docs/final/week13-refactoring.md
@@ -86,15 +86,15 @@ Additionally, the **frequency route** did not use Zod at all. It contained a 60-
 
 ### Files Affected
 
-| File | Change |
-|------|--------|
-| `lib/validation/schemas.ts` | Added `frequencyEventSchema` Zod schema |
-| `lib/validation/parseRequestBody.ts` | **New file** — shared JSON parse + validate utility |
-| `app/api/policies/route.ts` | Replaced inline validation with `parseRequestBody` |
-| `app/api/sessions/route.ts` | Replaced inline validation with `parseRequestBody` |
-| `app/api/sessions/[sessionId]/transcript-events/route.ts` | Replaced inline validation with `parseRequestBody` |
-| `app/api/sessions/[sessionId]/frequency/route.ts` | Removed hand-rolled validator, replaced with `frequencyEventSchema` + `parseRequestBody` |
-| `app/__tests__/parse-request-body.test.ts` | **New file** — 16 tests covering the refactored code |
+| File                                                      | Change                                                                                   |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `lib/validation/schemas.ts`                               | Added `frequencyEventSchema` Zod schema                                                  |
+| `lib/validation/parseRequestBody.ts`                      | **New file** — shared JSON parse + validate utility                                      |
+| `app/api/policies/route.ts`                               | Replaced inline validation with `parseRequestBody`                                       |
+| `app/api/sessions/route.ts`                               | Replaced inline validation with `parseRequestBody`                                       |
+| `app/api/sessions/[sessionId]/transcript-events/route.ts` | Replaced inline validation with `parseRequestBody`                                       |
+| `app/api/sessions/[sessionId]/frequency/route.ts`         | Removed hand-rolled validator, replaced with `frequencyEventSchema` + `parseRequestBody` |
+| `app/__tests__/parse-request-body.test.ts`                | **New file** — 16 tests covering the refactored code                                     |
 
 ### Why the New Structure Is Better
 
@@ -109,12 +109,14 @@ Additionally, the **frequency route** did not use Zod at all. It contained a 60-
 **File:** `app/__tests__/parse-request-body.test.ts` (16 tests)
 
 **`parseRequestBody` utility tests (4):**
+
 - Returns parsed data for valid requests
 - Returns 400 for malformed JSON
 - Returns 400 with field-level error messages for schema violations
 - Returns 400 for completely wrong input shape
 
 **`frequencyEventSchema` tests (12):**
+
 - Accepts valid frequency events
 - Accepts zero for `dominantFrequencyHz` (edge case: silence)
 - Accepts empty `frequencyBins` array

--- a/docs/final/week13-refactoring.md
+++ b/docs/final/week13-refactoring.md
@@ -1,0 +1,136 @@
+# Week 13 — Refactoring + Code Health Improvements
+
+## Code Health Problems Identified
+
+### Problem 1: Duplicated Request Validation Boilerplate + Inconsistent Frequency Validation (Refactored)
+
+**What:** Every POST API route handler repeated 15–20 lines of identical boilerplate for JSON body parsing and schema validation:
+
+```typescript
+let body: unknown;
+try {
+  body = await request.json();
+} catch {
+  logger.error("api.error", { ... });
+  return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+}
+
+const parsed = someSchema.safeParse(body);
+if (!parsed.success) {
+  const message = formatZodError(parsed.error.issues);
+  logger.error("api.error", { ... });
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+```
+
+This pattern was copy-pasted into 4 route handlers:
+
+- `POST /api/policies` (`app/api/policies/route.ts`)
+- `POST /api/sessions` (`app/api/sessions/route.ts`)
+- `POST /api/sessions/[id]/transcript-events` (`app/api/sessions/[sessionId]/transcript-events/route.ts`)
+- `POST /api/sessions/[id]/frequency` (`app/api/sessions/[sessionId]/frequency/route.ts`)
+
+Additionally, the **frequency route** did not use Zod at all. It contained a 60-line hand-rolled `validateFrequencyEvent()` function with deeply nested `if`-statements and manual type-narrowing via `as` casts. Every other route used Zod schemas from `lib/validation/schemas.ts`, making the frequency route an inconsistency in the codebase.
+
+**Why it was a problem:**
+
+- **DRY violation:** 60+ lines of duplicated validation logic across 4 files.
+- **Inconsistency:** Three routes used Zod; one used a hand-rolled validator with different error message formats.
+- **Maintenance burden:** Any change to validation behavior (e.g., error response format, logging fields) had to be replicated in 4 places.
+- **Type safety gap:** The frequency route used `as` casts to narrow `unknown` to concrete types after hand-rolled checks, while Zod-based routes got full type inference for free.
+
+---
+
+### Problem 2: Duplicated Client-Side Types and UI Constants (Deferred)
+
+**What:** Multiple page components (`call/page.tsx`, `history/page.tsx`) redefine the same TypeScript interfaces and Tailwind color constants locally instead of importing them from a shared location:
+
+- `ChecklistRow` — defined identically in `call/page.tsx:12–16` and `history/page.tsx:25–29` (already exists as `ChecklistStateRow` in `lib/domain/types.ts:70–74`)
+- `TranscriptEntry` — defined identically in `call/page.tsx:18–23` and `history/page.tsx:19–23` (already exists in `lib/domain/types.ts:50–59`)
+- `ThreatScore` — defined identically in both pages (exists as `ThreatScoreBreakdown` in `lib/domain/types.ts:95–101`)
+- `LEVEL_COLORS` and `LEVEL_BG` — identical Tailwind class maps duplicated in both pages
+- `authHeaders()` helper — reimplemented in both pages with slightly different `getToken()` strategies (cookies vs. localStorage)
+
+**Why it was a problem:**
+
+- **Divergence risk:** If the domain type changes (e.g., adding a `speaker` field to `TranscriptEntry`), page-local copies won't update.
+- **Maintenance burden:** UI color changes require updating 2+ files.
+- **Inconsistent auth behavior:** `call/page.tsx` reads tokens from cookies while `history/page.tsx` reads from localStorage — a subtle bug vector.
+
+**Why deferred:** This is a frontend-only change with lower blast radius than the API validation refactor. The page components still function correctly; the risk is future divergence rather than current breakage. Recommended for Week 14.
+
+---
+
+## Refactor Completed: Problem 1
+
+### What Changed
+
+1. **New `frequencyEventSchema` added to `lib/validation/schemas.ts`**
+   - Replaces the 60-line hand-rolled `validateFrequencyEvent()` function
+   - Validates all 5 required fields: `dominantFrequencyHz`, `frequencyBins`, `sampleRateHz`, `fftSize`, `binResolutionHz`
+   - Enforces the same constraints as the old validator (non-negative, finite, positive, integer, max array length 4096)
+   - Provides type inference via `z.infer<typeof frequencyEventSchema>`
+
+2. **New `parseRequestBody()` utility created at `lib/validation/parseRequestBody.ts`**
+   - Generic function: `parseRequestBody<T>(request, schema, route, sessionId?)`
+   - Handles JSON parsing errors (returns 400 with "Invalid JSON body")
+   - Handles Zod validation failures (returns 400 with field-level error message via `formatZodError`)
+   - Logs all failures with the route name and optional session ID for traceability
+   - Returns a discriminated union (`{ success: true, data } | { success: false, response }`) matching the existing `authenticateRequest()` pattern
+
+3. **All 4 POST route handlers updated** to use `parseRequestBody()` instead of inline boilerplate:
+   - `app/api/policies/route.ts` — removed 17 lines of boilerplate
+   - `app/api/sessions/route.ts` — removed 15 lines of boilerplate
+   - `app/api/sessions/[sessionId]/transcript-events/route.ts` — removed 17 lines of boilerplate
+   - `app/api/sessions/[sessionId]/frequency/route.ts` — removed 80+ lines (60-line validator + 15 lines of parsing boilerplate)
+
+### Files Affected
+
+| File | Change |
+|------|--------|
+| `lib/validation/schemas.ts` | Added `frequencyEventSchema` Zod schema |
+| `lib/validation/parseRequestBody.ts` | **New file** — shared JSON parse + validate utility |
+| `app/api/policies/route.ts` | Replaced inline validation with `parseRequestBody` |
+| `app/api/sessions/route.ts` | Replaced inline validation with `parseRequestBody` |
+| `app/api/sessions/[sessionId]/transcript-events/route.ts` | Replaced inline validation with `parseRequestBody` |
+| `app/api/sessions/[sessionId]/frequency/route.ts` | Removed hand-rolled validator, replaced with `frequencyEventSchema` + `parseRequestBody` |
+| `app/__tests__/parse-request-body.test.ts` | **New file** — 16 tests covering the refactored code |
+
+### Why the New Structure Is Better
+
+- **Single source of truth:** Validation boilerplate lives in one place. Changing error format, logging structure, or response shape requires editing one file.
+- **Consistent validation strategy:** All routes now use Zod schemas. No more hand-rolled validators with different error formats.
+- **Type-safe by default:** `parseRequestBody` returns `z.infer<T>` — callers get fully typed data without `as` casts.
+- **Reduced route handler size:** Each route handler is 15–80 lines shorter, making business logic easier to read.
+- **Follows existing patterns:** The discriminated-union return type mirrors `authenticateRequest()`, so the calling pattern is familiar to anyone working in this codebase.
+
+### Tests Added
+
+**File:** `app/__tests__/parse-request-body.test.ts` (16 tests)
+
+**`parseRequestBody` utility tests (4):**
+- Returns parsed data for valid requests
+- Returns 400 for malformed JSON
+- Returns 400 with field-level error messages for schema violations
+- Returns 400 for completely wrong input shape
+
+**`frequencyEventSchema` tests (12):**
+- Accepts valid frequency events
+- Accepts zero for `dominantFrequencyHz` (edge case: silence)
+- Accepts empty `frequencyBins` array
+- Rejects negative `dominantFrequencyHz`
+- Rejects `NaN` values
+- Rejects `Infinity` values
+- Rejects zero `sampleRateHz` (must be positive)
+- Rejects non-integer `fftSize`
+- Rejects zero `fftSize`
+- Rejects non-number elements in `frequencyBins`
+- Rejects missing required fields
+- Rejects `frequencyBins` exceeding max length (4096)
+
+All 17 pre-existing tests covering the affected routes continue to pass, confirming behavior preservation.
+
+### Related PR
+
+- PR: TBD (this branch: `refactor/extract-request-validation-helper`)
+- Teammate's PR: #56 (sprint goal / hand-off)

--- a/lib/validation/parseRequestBody.ts
+++ b/lib/validation/parseRequestBody.ts
@@ -41,9 +41,10 @@ export async function parseRequestBody<T extends z.ZodType>(
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     const message = formatZodError(parsed.error.issues);
+    const field = String(parsed.error.issues[0]?.path?.[0] ?? "");
     logger.error("api.error", {
       ...(sessionId && { sessionId }),
-      data: { route, status: 400, reason: message },
+      data: { route, status: 400, ...(field && { field }), reason: message },
     });
     return {
       success: false,

--- a/lib/validation/parseRequestBody.ts
+++ b/lib/validation/parseRequestBody.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import type { z } from "zod/v4";
+import { formatZodError } from "@/lib/validation/schemas";
+import { logger } from "@/lib/logger";
+
+/**
+ * Parse the JSON body of a request and validate it against a Zod schema.
+ *
+ * Returns `{ success: true, data }` when valid, or
+ * `{ success: false, response }` with a pre-built 400 NextResponse when not.
+ *
+ * Handles both malformed JSON and schema validation failures, logging each
+ * with the route name for traceability.
+ */
+export async function parseRequestBody<T extends z.ZodType>(
+  request: Request,
+  schema: T,
+  route: string,
+  sessionId?: string
+): Promise<
+  | { success: true; data: z.infer<T> }
+  | { success: false; response: NextResponse }
+> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    logger.error("api.error", {
+      ...(sessionId && { sessionId }),
+      data: { route, status: 400, reason: "Invalid JSON body" },
+    });
+    return {
+      success: false,
+      response: NextResponse.json(
+        { error: "Invalid JSON body" },
+        { status: 400 }
+      ),
+    };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    const message = formatZodError(parsed.error.issues);
+    logger.error("api.error", {
+      ...(sessionId && { sessionId }),
+      data: { route, status: 400, reason: message },
+    });
+    return {
+      success: false,
+      response: NextResponse.json({ error: message }, { status: 400 }),
+    };
+  }
+
+  return { success: true, data: parsed.data };
+}

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -85,3 +85,36 @@ export const createPolicyBodySchema = z.object({
       `'text' must be at most ${POLICY_TEXT_MAX_LENGTH} characters`
     ),
 });
+
+/* ── Frequency event ─────────────────────────── */
+
+const MAX_FREQUENCY_BINS = 4096;
+
+export const frequencyEventSchema = z.object({
+  dominantFrequencyHz: z
+    .number({ error: "'dominantFrequencyHz' must be a number" })
+    .finite("'dominantFrequencyHz' must be a finite number")
+    .min(0, "'dominantFrequencyHz' must be a finite non-negative number"),
+  frequencyBins: z
+    .array(
+      z
+        .number({ error: "each frequency bin must be a number" })
+        .finite("each frequency bin must be a finite number")
+    )
+    .max(
+      MAX_FREQUENCY_BINS,
+      `'frequencyBins' exceeds maximum length of ${MAX_FREQUENCY_BINS}`
+    ),
+  sampleRateHz: z
+    .number({ error: "'sampleRateHz' must be a number" })
+    .finite("'sampleRateHz' must be a finite number")
+    .positive("'sampleRateHz' must be a positive finite number"),
+  fftSize: z
+    .number({ error: "'fftSize' must be a number" })
+    .int("'fftSize' must be a positive integer")
+    .positive("'fftSize' must be a positive integer"),
+  binResolutionHz: z
+    .number({ error: "'binResolutionHz' must be a number" })
+    .finite("'binResolutionHz' must be a finite number")
+    .positive("'binResolutionHz' must be a positive finite number"),
+});


### PR DESCRIPTION
## Summary

Extract a shared `parseRequestBody()` utility that replaces 15–20 lines of duplicated JSON-parse + Zod-validate boilerplate repeated across 4 POST route handlers. Convert the frequency route from a 60-line hand-rolled validator to a declarative Zod schema (`frequencyEventSchema`), making all API routes use a consistent validation strategy. Add Week 13 Deliverable B documentation.

---

## Why

Every POST route duplicated the same try/catch JSON parsing, `safeParse`, `formatZodError`, logging, and error-response pattern. The frequency route was the worst offender — it used a completely different validation approach (hand-rolled `if`-chains with `as` casts) while every other route used Zod. This made validation behavior inconsistent and maintenance error-prone.

---

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure/CI

---

## Checklist

- [x] Branch follows naming convention
- [x] PR opened early
- [x] CI checks pass
- [x] Lint/format run locally
- [x] At least one reviewer assigned
- [x] Tests added or test plan described
- [x] Documentation updated (if applicable)

---

## Notes for Reviewer

- All 17 pre-existing tests for affected routes still pass — behavior is preserved.
- 16 new tests added in `app/__tests__/parse-request-body.test.ts` (4 for the `parseRequestBody` utility, 12 for `frequencyEventSchema`).
- The `parseRequestBody` return type uses the same discriminated-union pattern as `authenticateRequest()`, so the calling convention is consistent.
- `docs/final/week13-refactoring.md` documents 2 code health problems found; Problem 2 (duplicated client-side types) is deferred to Week 14.

### Files changed

| File | Change |
|------|--------|
| `lib/validation/parseRequestBody.ts` | **New** — shared JSON parse + Zod validate utility |
| `lib/validation/schemas.ts` | Added `frequencyEventSchema` |
| `app/api/policies/route.ts` | Use `parseRequestBody` (−17 lines) |
| `app/api/sessions/route.ts` | Use `parseRequestBody` (−15 lines) |
| `app/api/sessions/[sessionId]/transcript-events/route.ts` | Use `parseRequestBody` (−17 lines) |
| `app/api/sessions/[sessionId]/frequency/route.ts` | Remove hand-rolled validator, use Zod + `parseRequestBody` (−80 lines) |
| `app/__tests__/parse-request-body.test.ts` | **New** — 16 tests |
| `docs/final/week13-refactoring.md` | **New** — Week 13 Deliverable B |