### PR TITLE
feat(auth): add JWT revocation via JTI denylist and logout endpoint

### DIFF
--- a/__tests__/week11-reliability.test.ts
+++ b/__tests__/week11-reliability.test.ts
@@ -67,7 +67,13 @@ describe("Full session lifecycle workflow", () => {
     }
 
     // 6. List sessions via history — ended session must appear
-    const auth = { userId: AGENT_USER_ID, email: "", role: "agent" as const };
+    const auth = {
+      userId: AGENT_USER_ID,
+      email: "",
+      role: "agent" as const,
+      jti: "test-jti",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
     const sessions = await listSessionsForUser(auth, "ended");
     const found = sessions.find((s) => s.id === session.id);
     expect(found).toBeDefined();

--- a/app/__tests__/auth-access-control.test.ts
+++ b/app/__tests__/auth-access-control.test.ts
@@ -8,6 +8,8 @@ import {
   AGENT_USER_ID,
 } from "@/lib/test-helpers/auth";
 import { ensureSeedUsers } from "@/lib/repositories/seedUsers";
+import { signToken } from "@/lib/auth";
+import { getUserByEmail } from "@/lib/repositories/userRepo";
 
 beforeAll(async () => {
   await ensureSeedUsers();
@@ -172,5 +174,99 @@ describe("session ownership", () => {
     });
 
     expect(res.status).toBe(200);
+  });
+});
+
+/* ── Logout / token revocation ────────────────── */
+
+describe("POST /api/auth/logout", () => {
+  async function mintAgentToken(): Promise<string> {
+    const user = await getUserByEmail("agent@sentinel.local");
+    if (!user) throw new Error("agent seed user missing");
+    return signToken(user);
+  }
+
+  it("returns 200 and clears the cookie for a valid token", async () => {
+    const token = await mintAgentToken();
+    const { POST } = await import("@/app/api/auth/logout/route");
+    const res = await POST(
+      new Request("http://localhost/api/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toMatch(/token=;/);
+    expect(setCookie).toMatch(/Max-Age=0/);
+  });
+
+  it("returns 401 when no token is supplied", async () => {
+    const { POST } = await import("@/app/api/auth/logout/route");
+    const res = await POST(
+      new Request("http://localhost/api/auth/logout", { method: "POST" })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("revokes the token so subsequent protected requests return 401", async () => {
+    const token = await mintAgentToken();
+    const { POST: logout } = await import("@/app/api/auth/logout/route");
+    await logout(
+      new Request("http://localhost/api/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    );
+
+    const { POST: createSession } = await import("@/app/api/sessions/route");
+    const res = await createSession(
+      new Request("http://localhost/api/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ policyId: "any" }),
+      })
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/revoked/i);
+  });
+
+  it("only revokes the specific jti — a freshly issued token still works", async () => {
+    const tokenA = await mintAgentToken();
+    const { POST: logout } = await import("@/app/api/auth/logout/route");
+    await logout(
+      new Request("http://localhost/api/auth/logout", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${tokenA}` },
+      })
+    );
+
+    // New login → new token → should be accepted.
+    const tokenB = await mintAgentToken();
+    expect(tokenB).not.toBe(tokenA);
+
+    const policy = await createPolicyFromText("Post-Revoke", "Step");
+    const { POST: createSession } = await import("@/app/api/sessions/route");
+    const res = await createSession(
+      new Request("http://localhost/api/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${tokenB}`,
+        },
+        body: JSON.stringify({ policyId: policy.id }),
+      })
+    );
+
+    expect(res.status).toBe(201);
   });
 });

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { authenticateRequest, authErrorResponse } from "@/lib/auth";
+import { revokeToken } from "@/lib/repositories/revokedTokenRepo";
+import { logger } from "@/lib/logger";
+
+export async function POST(request: Request) {
+  const start = performance.now();
+  const result = await authenticateRequest(request);
+
+  if (!result.success) {
+    return authErrorResponse(result.error);
+  }
+
+  const { auth } = result;
+  await revokeToken(auth.jti, auth.userId, new Date(auth.exp * 1000));
+
+  const durationMs = Math.round(performance.now() - start);
+  logger.info("auth.logout", {
+    data: { userId: auth.userId, jti: auth.jti, durationMs },
+  });
+
+  const response = NextResponse.json({ success: true }, { status: 200 });
+  response.headers.set(
+    "Set-Cookie",
+    "token=; HttpOnly; Path=/; SameSite=Strict; Max-Age=0"
+  );
+  return response;
+}

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -34,7 +34,18 @@ export default function NavBar() {
 
   if (pathname === "/login") return null;
 
-  function handleLogout() {
+  async function handleLogout() {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+    } catch {
+      // Swallow — client-side state still needs to clear so the user can leave.
+    }
     localStorage.removeItem("token");
     document.cookie = "token=; Path=/; Max-Age=0";
     window.dispatchEvent(new Event("storage"));

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -119,7 +119,16 @@ export default function DemoPage() {
     };
   }
 
-  function handleLogout() {
+  async function handleLogout() {
+    try {
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+        headers: authHeaders(),
+      });
+    } catch {
+      // Network failure shouldn't trap the user on /demo — still clear client state.
+    }
     localStorage.removeItem("token");
     document.cookie = "token=; Path=/; Max-Age=0";
     window.dispatchEvent(new Event("storage"));

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   testEnvironment: "jest-environment-jsdom",
   moduleNameMapper: {
     "^@/lib/db$": `${ROOT}/lib/__mocks__/db.ts`,
-    "^@/lib/repositories/(sessionRepo|policyRepo|transcriptRepo|checklistStateRepo|frequencyRepo|userRepo|seedUsers)$": `${ROOT}/lib/repositories/__test-impl__/$1`,
+    "^@/lib/repositories/(sessionRepo|policyRepo|transcriptRepo|checklistStateRepo|frequencyRepo|userRepo|seedUsers|revokedTokenRepo)$": `${ROOT}/lib/repositories/__test-impl__/$1`,
     "^@/(.*)$": `${ROOT}/$1`,
   },
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,8 @@
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { SignJWT, jwtVerify } from "jose";
 import { NextResponse } from "next/server";
 import { Session, User, UserRole } from "@/lib/domain/types";
+import { isTokenRevoked } from "@/lib/repositories/revokedTokenRepo";
 
 const JWT_SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET || "dev-secret-change-me-in-production"
@@ -21,20 +22,38 @@ export async function signToken(user: User): Promise<string> {
   return new SignJWT({ email: user.email, role: user.role })
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(user.id)
+    .setJti(randomUUID())
     .setIssuedAt()
     .setExpirationTime(TOKEN_EXPIRY)
     .sign(JWT_SECRET);
 }
 
+export interface VerifiedPayload {
+  sub: string;
+  email: string;
+  role: UserRole;
+  jti: string;
+  exp: number;
+}
+
 export async function verifyToken(
   token: string
-): Promise<{ sub: string; email: string; role: UserRole } | null> {
+): Promise<VerifiedPayload | null> {
   try {
     const { payload } = await jwtVerify(token, JWT_SECRET);
+    if (
+      typeof payload.sub !== "string" ||
+      typeof payload.jti !== "string" ||
+      typeof payload.exp !== "number"
+    ) {
+      return null;
+    }
     return {
-      sub: payload.sub as string,
+      sub: payload.sub,
       email: payload.email as string,
       role: payload.role as UserRole,
+      jti: payload.jti,
+      exp: payload.exp,
     };
   } catch {
     return null;
@@ -45,9 +64,11 @@ export interface AuthResult {
   userId: string;
   email: string;
   role: UserRole;
+  jti: string;
+  exp: number;
 }
 
-export type AuthError = "missing_token" | "invalid_token";
+export type AuthError = "missing_token" | "invalid_token" | "revoked_token";
 
 export async function authenticateRequest(
   request: Request
@@ -76,9 +97,19 @@ export async function authenticateRequest(
     return { success: false, error: "invalid_token" };
   }
 
+  if (await isTokenRevoked(payload.jti)) {
+    return { success: false, error: "revoked_token" };
+  }
+
   return {
     success: true,
-    auth: { userId: payload.sub, email: payload.email, role: payload.role },
+    auth: {
+      userId: payload.sub,
+      email: payload.email,
+      role: payload.role,
+      jti: payload.jti,
+      exp: payload.exp,
+    },
   };
 }
 
@@ -86,6 +117,12 @@ export function authErrorResponse(error: AuthError): NextResponse {
   if (error === "missing_token") {
     return NextResponse.json(
       { error: "Authentication required" },
+      { status: 401 }
+    );
+  }
+  if (error === "revoked_token") {
+    return NextResponse.json(
+      { error: "Token has been revoked" },
       { status: 401 }
     );
   }

--- a/lib/repositories/__test-impl__/revokedTokenRepo.ts
+++ b/lib/repositories/__test-impl__/revokedTokenRepo.ts
@@ -1,0 +1,16 @@
+const g = globalThis as unknown as { _revokedJtis?: Set<string> };
+const revoked = (g._revokedJtis ??= new Set<string>());
+
+export async function revokeToken(
+  jti: string,
+  userId: string,
+  expiresAt: Date
+): Promise<void> {
+  void userId;
+  void expiresAt;
+  revoked.add(jti);
+}
+
+export async function isTokenRevoked(jti: string): Promise<boolean> {
+  return revoked.has(jti);
+}

--- a/lib/repositories/revokedTokenRepo.ts
+++ b/lib/repositories/revokedTokenRepo.ts
@@ -1,0 +1,18 @@
+import { prisma } from "@/lib/db";
+
+export async function revokeToken(
+  jti: string,
+  userId: string,
+  expiresAt: Date
+): Promise<void> {
+  await prisma.revokedToken.upsert({
+    where: { jti },
+    update: {},
+    create: { jti, userId, expiresAt },
+  });
+}
+
+export async function isTokenRevoked(jti: string): Promise<boolean> {
+  const row = await prisma.revokedToken.findUnique({ where: { jti } });
+  return row !== null;
+}

--- a/prisma/migrations/20260422000000_add_revoked_token/migration.sql
+++ b/prisma/migrations/20260422000000_add_revoked_token/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "revoked_tokens" (
+    "jti" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "revoked_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "revoked_tokens_pkey" PRIMARY KEY ("jti")
+);
+
+-- CreateIndex
+CREATE INDEX "revoked_tokens_expires_at_idx" ON "revoked_tokens"("expires_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,3 +98,13 @@ model ChecklistState {
   @@id([sessionId, itemId])
   @@map("checklist_states")
 }
+
+model RevokedToken {
+  jti       String   @id
+  userId    String   @map("user_id")
+  revokedAt DateTime @default(now()) @map("revoked_at")
+  expiresAt DateTime @map("expires_at")
+
+  @@index([expiresAt])
+  @@map("revoked_tokens")
+}


### PR DESCRIPTION
## Summary

Closes the **Auth Hardening (Revocation)** item from the Week 15 sprint backlog (`docs/final/week15-sprint.md` row 1) and fixes the weakness called out in `docs/handoff/hand-off.md §5` (PR #67).

Tokens now carry a random `jti`. On logout, the server inserts the jti into a new `revoked_tokens` Postgres table; `authenticateRequest` checks the denylist after JWT verification and returns `401 revoked_token` for reuse attempts. Per-jti revocation means a freshly issued token after logout continues to work — only the specific session ends.

## Changes

- **Schema:** new `RevokedToken` model (`jti PK`, `userId`, `revokedAt`, `expiresAt`, indexed by `expiresAt` for GC). Migration `20260422000000_add_revoked_token`.
- **`lib/auth.ts`:** `signToken` adds `.setJti(randomUUID())`; `verifyToken` returns `{sub, email, role, jti, exp}`; `authenticateRequest` adds denylist check; `AuthError` gains `"revoked_token"`.
- **`POST /api/auth/logout`:** authenticated, idempotent, clears the `token` cookie.
- **Client:** `app/components/NavBar.tsx` and `app/demo/page.tsx` `handleLogout` now `POST /api/auth/logout` (with the Bearer header) before clearing client state. Network failures are swallowed so a user on a flaky connection can still sign out locally.
- **Tests:** 4 new cases in `app/__tests__/auth-access-control.test.ts` — valid-token logout, missing-token 401, token-reuse-after-revoke 401, per-jti isolation. In-memory test-impl uses a module-scoped `Set<string>`.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure/CI

## Checklist

- [x] Branch follows naming convention
- [x] CI checks pass locally (lint, format:check, tsc --noEmit, jest, next build)
- [x] Lint/format run locally
- [x] At least one reviewer assigned
- [x] Tests added (4 new revocation cases; full suite 109 passing)
- [x] Documentation updated (hand-off "deferred" item is now addressed — follow-up doc edit to come)

## Notes for Reviewer

- The migration ships as a hand-written `migration.sql` (I don't have Postgres running locally); Prisma should pick it up cleanly on `npx prisma migrate deploy`. If you spot a drift when running `migrate dev`, shout and I'll regenerate.
- There's a tiny diff in `__tests__/week11-reliability.test.ts` because `AuthResult` gained required `jti`/`exp` fields — one hand-constructed auth literal needed the new keys.
- Intentionally **not** expiring/pruning old denylist rows yet — that's a cron job for Week 16 polish. The `expiresAt` index is in place so cleanup is trivial when we get there.